### PR TITLE
Fixes to links and other formatting adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ View the Docs @ [docs.cmv.io](http://docs.cmv.io)
 ### Contributing to the Documentation
 
 1. __Submit a Pull Request__ - If you would like to contribute to the CMV documents, [pull requests](https://github.com/cmv/cmv-docs/pulls) are welcome.
+  1. Fork this repository.
+  2. Clone it to your local machine `git clone /path/to/your/repository`
+  3. Build the docs and develop them with live reload (python required)
+    ```
+    pip install mkdocs
+    mkdocs serve
+    ```
+  4. Commit your changes and push them to github
+    ```
+    git commit -m "I've updated the docs!"
+    git push origin/master
+    ```
 
 2. __Submit an Issue__ - Find a small typo and working with GitHub repos isn't your thing? Feel free to [submit an issue](https://github.com/cmv/cmv-docs/issues).
 

--- a/configure/basemaps.md
+++ b/configure/basemaps.md
@@ -1,49 +1,49 @@
 This file comes with the standard ESRI basemaps already configured to work with the application. Should you want to use your own custom basemaps or mash them up with ESRI basemaps there are a couple of ways to do this.
 
-### What Options Are Available?
+## What Options Are Available?
 1. In an effort to not duplicate documentation it is strongly recommended you become familiar with the ArcGIS API for Javascript.
 
-2. To understand the different parameters or options available to you. 
+2. To understand the different parameters or options available to you.
 
  a) For further customizing your Basemap please refer to  the [ArcGIS API for Javascript -- Basemap](https://developers.arcgis.com/javascript/jsapi/basemap-amd.html).
 
  b) For further customizing your BasemapLayer please refer to the [ArcGIS API for Javascript -- BasemapLayer](https://developers.arcgis.com/javascript/jsapi/basemaplayer-amd.html).
 
-### Getting Started with custom basemaps
+## Getting Started with custom basemaps
 1. In the file `\viewer\js\config\basemaps.js` change `mode: 'agol',` to `mode: 'custom',`
 
-2. Block Comment the preconfigured AGOL basemaps so you can use your custom basemaps. 
+2. Block Comment the preconfigured AGOL basemaps so you can use your custom basemaps.
 ``` javascript
 /*streets: {
-                title: 'Streets'
-            },
-            satellite: {
-                title: 'Satellite'
-            },
-            hybrid: {
-                title: 'Hybrid'
-            },
-            topo: {
-                title: 'Topo'
-            },
-            gray: {
-                title: 'Gray'
-            },
-            oceans: {
-                title: 'Oceans'
-            },
-            'national-geographic': {
-                title: 'Nat Geo'
-            },
-            osm: {
-                title: 'Open Street Map'
-            }
+      title: 'Streets'
+  },
+  satellite: {
+      title: 'Satellite'
+  },
+  hybrid: {
+      title: 'Hybrid'
+  },
+  topo: {
+      title: 'Topo'
+  },
+  gray: {
+      title: 'Gray'
+  },
+  oceans: {
+      title: 'Oceans'
+  },
+  'national-geographic': {
+      title: 'Nat Geo'
+  },
+  osm: {
+      title: 'Open Street Map'
+  }
 */
 ```
 3. **It is recommended when getting started to not delete code right away. By commenting the code you have something you can refer back to.**
 
-###  Implementing your custom basemaps
-1. Remove the Block Comment in the example section of `\viewer\js\config\basemaps.js` for custom basemaps. 
+##  Implementing your custom basemaps
+1. Remove the Block Comment in the example section of `\viewer\js\config\basemaps.js` for custom basemaps.
 ``` javascript
 // examples of custom basemaps
 
@@ -102,19 +102,19 @@ This file comes with the standard ESRI basemaps already configured to work with 
 
 ```javascript
 streets: {
-                title: 'Streets',
-                basemap: new Basemap({
-                    id: 'streets',
-                    layers: [new BasemapLayer({
-                        url: 'http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
-                    })]
-                })
-            },
+    title: 'Streets',
+    basemap: new Basemap({
+        id: 'streets',
+        layers: [new BasemapLayer({
+            url: 'http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+        })]
+    })
+},
 ```
 
 **Note:** If you were to change the function name from `streets:{}` to `streetscustom:{}` then you would also need to add or change the name in the `basemapsToShow:[]` array to match the name of your function. An example of how this might be done is below.
 
-#### Example configuration to use custom basemaps displayed in the Basemap Gallery
+### Example configuration to use custom basemaps displayed in the Basemap Gallery
 
 ```javascript
 // at CMV version 1.3.0 the three defines below are included and commented out.
@@ -175,8 +175,8 @@ define([
 3. If your tiled services have scales or levels of detail that go in beyond the Esri scales, you can still take advantage of those scales but continue using Esri basemap services albeit with a little more customization.
 
 
-## Zooming in beyond Esri default scales or levels of detail.
- 
+### Zooming in beyond Esri default scales or levels of detail.
+
 **There might be multiple ways to do this so if there are other examples please share. But here is one example.**
 
 * Create a map service and enable caching using your scales, but choose the option to generate tiles manually.
@@ -184,38 +184,38 @@ define([
 * This will publish a service with your scales or levels of detail. While it appears like a cache service     there was no time spent creating the tiles. It is merely being used to define your scales or levels of detail.
 
 * In this example, the service defining scales or levels of detail is called **LODS**. Notice it is the first service defined in Basemap as a BasemapLayer. Therefore the streets Basemap should assume the scales or levels of detail of the **LODS** service. Although we still need to make some other customizations.
- 
-``` basemaps.js ```
 
- ```javascript
+```javascript
+
+//basemaps.js
  streets: {
-                title: 'Clermont County Streets',
-                basemap: new Basemap({
-                    id: 'streets',
-                    layers: [new BasemapLayer({
-                        url: 'http://maps.clermontauditor.org/arcgis/rest/services/WMAS/LODS/MapServer'
-                    }), new BasemapLayer({
-                        url: 'http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
-                    }), new BasemapLayer({
-                        url: 'http://maps.clermontauditor.org/arcgis/rest/services/WMAS/Streetmap/MapServer'
-                    })]
-                })
-            },
- ```
+    title: 'Clermont County Streets',
+    basemap: new Basemap({
+        id: 'streets',
+        layers: [new BasemapLayer({
+            url: 'http://maps.clermontauditor.org/arcgis/rest/services/WMAS/LODS/MapServer'
+        }), new BasemapLayer({
+            url: 'http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+        }), new BasemapLayer({
+            url: 'http://maps.clermontauditor.org/arcgis/rest/services/WMAS/Streetmap/MapServer'
+        })]
+    })
+},
+```
 
 * By design the template is built to work with Esri basemaps. So the first basemap which gets loaded in the ``` viewer.js ``` file is **streets**. So even if you follow the above steps in ``` basemaps.js ``` the scales will not be honored until some customizations are made to **viewer.js**.
 
 * Around line 23 look for the block of code below. This is what you will need to customize so your scales or levels of detail will be honored when the application loads.
 
-``` viewer.js ```
-
 ```javascript
-		mapOptions: {
-			basemap: 'streets',
-			center: [-96.59179687497497, 39.09596293629694],
-			zoom: 5,
-			sliderStyle: 'small'
-		},
+// viewer.js
+
+mapOptions: {
+  	basemap: 'streets',
+  	center: [-96.59179687497497, 39.09596293629694],
+  	zoom: 5,
+  	sliderStyle: 'small'
+},
 ```
 
 * You will need to create a Basemap and add a BasemapLayer which references your scales.

--- a/configure/index.md
+++ b/configure/index.md
@@ -1,5 +1,7 @@
 # Configuration
 
-Use the configuration files in the `/js/config` folder to customize your own map layers, task urls and widgets. The base configuration file is [viewer.js](configure/viewer) and the majority of your work will be here.
+Use the configuration files in the `/js/config` folder to customize your own map layers, task urls and widgets. The base configuration file is [viewer.js](./viewer) and the majority of your work will be here.
 
-Sometimes the configuration object for a widget can be quite involved and length. In those cases, it often makes it easier to separate that widget's configuration into a separate file. Configurations for the [Basemaps](configure/basemaps) and [Identify](configure/identify) widgets are frequently maintained this way. 
+Multiple cmv apps may be created by using several different config files, the default is `viewer.js`. This offers flexibility if you want to deploy more than one CMV on your site by using a url to call different configs within different `viewer.js` files. For example `http://YourServerName/viewer/?config=viewer2` to load a separate config file in config folder or to a completely different folder `http://YourServerName/viewer/?config=./js/newconfig/viewer.js`
+
+Sometimes the configuration object for a widget can be quite involved and length. In those cases, it often makes it easier to separate that widget's configuration into a separate file. Configurations for the [Basemaps](./basemaps) and [Identify](./identify) widgets are frequently maintained this way.

--- a/configure/mapOptions.md
+++ b/configure/mapOptions.md
@@ -6,7 +6,7 @@
 
 * If you want to have the large zoom slider in your map like this `sliderStyle: 'large'`, you will need to use the full build of the JavaScript API,  CMV uses the compact build by default.
 
-#### Example: mapOptions using a basemap from ArcGIS Online:
+## Example: mapOptions using a basemap from ArcGIS Online:
 ``` javascript
 mapOptions: {
    basemap: 'streets',
@@ -16,7 +16,7 @@ mapOptions: {
    showAttribution: true
 }
 ```
-#### Example: mapOptions using a custom basemap:
+## Example: mapOptions using a custom basemap:
 In the `define()` add references to `'esri/dijit/Basemap'`, `'esri/dijit/BasemapLayer'` and `'esri/geometry/Point'`
 ``` javascript
 mapOptions: {
@@ -39,7 +39,7 @@ mapOptions: {
 }
 ```
 
-#### Important Chrome Browser Tweak
+## Important Chrome Browser Tweak
 If you notice or experience the map or the application flashing while zooming in & out, or panning here is a workaround.
 
 In ``` config/viewer.js ``` under Map Options add ```navigationMode: 'classic'```
@@ -55,4 +55,3 @@ mapOptions: {
 }
 ```
 Here is a [link](https://developers.arcgis.com/javascript/jsapi/map-amd.html#navigationmode) to the ArcGIS Javascript API docs for a more detailed explanation.
- 

--- a/configure/operationalLayers.md
+++ b/configure/operationalLayers.md
@@ -1,6 +1,6 @@
 # Operational Layers Section of viewer.js
 
-Layers to load on top of the basemap. See [Class: Layer] (https://developers.arcgis.com/javascript/jsapi/layer-amd.html) for more information on types of layers and [Layer options] (https://developers.arcgis.com/javascript/jsapi/layer-amd.html#layer1).
+Layers to load on top of the basemap. See [Class: Layer](https://developers.arcgis.com/javascript/jsapi/layer-amd.html) for more information on types of layers and [Layer options](https://developers.arcgis.com/javascript/jsapi/layer-amd.html#layer1).
 
 Each layer object may consist of the following properties:
 
@@ -42,11 +42,11 @@ Setting `exclude: true` in the `legendLayerInfos` property allows you to exclude
 Setting `exclude: true` in the `identifyLayerInfos` property allows you to exclude the feature layer from the editor widget.
 
 ## Layer Control
-See the [layer control documentation](./LayerControl) for details on configuring the layer in this widget.
+See the [layer control documentation](../widgets/LayerControl) for details on configuring the layer in this widget.
 
 
 ## Example
-See [operational layers section in viewer.js] (https://github.com/cmv/cmv-app/blob/master/viewer/js/config/viewer.js#L63) for examples.
+See [operational layers section in viewer.js](https://github.com/cmv/cmv-app/blob/master/viewer/js/config/viewer.js#L63) for examples.
 
 ## Feature Layer Modes
 Feature layers have a default mode of `ON_DEMAND` so a value is not required. But if you would like to change the mode, you don't have to import `esri/layers/FeatureLayer`, instead you can use the integer value of the mode instead.
@@ -54,5 +54,5 @@ Feature layers have a default mode of `ON_DEMAND` so a value is not required. Bu
 Mode           | Integer value
 ---------------|--------------
 MODE_SNAPSHOT  | 0
-MODE_ONDEMAND  | 1 
+MODE_ONDEMAND  | 1
 MODE_SELECTION | 2

--- a/configure/panes.md
+++ b/configure/panes.md
@@ -2,7 +2,7 @@
 
 Basic guide for placing widgets in panes
 
-#### First add a bottom pane. Something like this near the top of your `viewer.js`:
+First add a bottom pane. Something like this near the top of your `viewer.js`:
 
 ``` javascript
 panes: {
@@ -22,7 +22,7 @@ panes: {
 },
 ```
 
-#### Then place your widget there by using `placeAt` in the widget options:
+Then place your widget there by using `placeAt` in the widget options:
 
 ```javascript
 widget: {
@@ -32,13 +32,13 @@ widget: {
 }
 ```
 
-#### That will work for widgets of type `titlePane` and `contentPane`. If you want to use a type of `domNode` you need some content in your pane to attach to:
+That will work for widgets of type `titlePane` and `contentPane`. If you want to use a type of `domNode` you need some content in your pane to attach to:
 
 ```javascript
 content: '<div id="myWidgetContainer"></div>'
 ```
 
-#### Then include the reference to that domNode in the widget options: 
+Then include the reference to that domNode in the widget options: 
 
 ```javascript
 widget: {

--- a/configure/titles.md
+++ b/configure/titles.md
@@ -10,6 +10,3 @@ titles: {
     pageTitle: 'Ours'
 },
 ```
-
-This offers flexibility if you want to deploy more than one CMV on your site by using a url to call different configs within different `viewer.js` files. For example http://YourServerName/viewer/?config=viewer2 to load a separate config file in config folder or to a completely different folder http://YourServerName/viewer/?config=./js/newconfig/viewer.js
-

--- a/configure/viewer.md
+++ b/configure/viewer.md
@@ -3,16 +3,16 @@ Use this file to configure CMV and "Make it your own".
 
 The following sections are contained within the viewer.js configuration file.
 
-#### [esriConfig](configure/esriConfig)
+#### [esriConfig](./esriConfig)
 
 #### Default Map Click Mode
 
-#### [Map Options](configure/mapOptions)
+#### [Map Options](./mapOptions)
 
-#### [Titles](configure/titles)
+#### [Titles](./titles)
 
-#### [Panes](configure/panes)
+#### [Panes](./panes)
 
-#### [Operational Layers](configure/operationalLayers)
+#### [Operational Layers](./operationalLayers)
 
-#### [Widgets](configure/widgets)
+#### [Widgets](./widgets)

--- a/configure/widgets.md
+++ b/configure/widgets.md
@@ -5,52 +5,52 @@ Widgets can have the following properties:
 {
     //load this widget definition
     include: true,
-    
+
     //can be: floating, titlePane, contentPane, map, domNode, invisible
     type: 'titlePane',
-       // titlePane type can undock from sidebar allowing user to position widget within browser 
+       // titlePane type can undock from sidebar allowing user to position widget within browser
         canFloat: true
-      
+
        //if titlePane type, additional pane locations are available: top, right, bottom
        //uncomment panes:{} section
        placeAt: 'right'
 
     //class file path to the widget
     path: 'gis/dijit/Print',
-    
+
     //id for widget must be unique
     id: 'print',
-    
-    //title for widget, will be used in titlePane and floating 
+
+    //title for widget, will be used in titlePane and floating
     title: 'Print',
-    
+
     //if titlePane, will be open or closed by default
     open: false,
-    
+
     //if titlePane type, the order in the sidebar when application is first opened
     position: 5,
-    
+
     //the dom node id to place the widget in for type domNode
     srcNodeRef: 'nodeId',
-    
+
     //options object will be passed into the widget class on creation
     options: {
-    
+
         //if you need a map reference true, if not false
         map: true,
-        
+
         // if you need the map click mode object
         mapClickMode: true,
-        
+
         // if you need the legend layer array
         legendLayerInfos: true,
-        
+
         // if you need the toc layer array
-        tocLayerInfos: true, 
+        tocLayerInfos: true,
 
         // if you need the edit layer array
         editorLayerInfos: true,
-        
+
         // any other property:value to pass into widget that you may need
         property: 'value'
     }
@@ -59,5 +59,4 @@ Widgets can have the following properties:
 
 
 #### Core Widgets
-The documentation for core CMV widgets is located [here](widgets/index).
-
+The documentation for core CMV widgets is located [here](../widgets/).

--- a/contribute/ContributingOnGitHub.md
+++ b/contribute/ContributingOnGitHub.md
@@ -1,4 +1,4 @@
-# Contributing on GitHub (DRAFT)
+# Contributing on GitHub
 
 Enhancements and bug fixes from the user community are essential for keeping CMV great. We want to keep it as easy as possible to contribute changes. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
@@ -12,9 +12,11 @@ Enhancements and bug fixes from the user community are essential for keeping CMV
 
 - Through [GitHub issues](https://github.com/cmv/cmv-app/issue/), or through the #cmv IRC channel on freenode.org, you talk about a feature you would like to see (or a bug), and why it should be in CMV.
 
+- There is also a [gitter.im chatroom](https://gitter.im/cmv/cmv-app), stop by sometime!
+
 - Create a topic branch from where you want to base your work.
 
-    - This is usually the `develop` branch.
+    - This is the `develop` branch.
 
     - To quickly create a topic branch based on develop; git checkout -b fix/my_contribution develop. Please avoid working directly on the master branch.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,13 +1,12 @@
 site_name: CMV
+site_description: CMV - The Configurable Map Viewer. Make it your own!
 site_url: http://cmv.io/
 dev_addr: '0.0.0.0:8000'
-use_absolute_urls: true
 
 repo_url: https://github.com/cmv/cmv-app
-description: CMV - The Configurable Map Viewer. Make it your own!
 
 docs_dir: ./
-
+strict: true
 theme: yeti
 #theme: spacelab
 #theme: readthedocs
@@ -62,4 +61,3 @@ pages:
   - License: about/license.md
   - Change Log: about/changelog.md
   - The CMV Team: about/team.md
-

--- a/widgets/Find.md
+++ b/widgets/Find.md
@@ -17,9 +17,9 @@ The Find widget allows you to configure multiple searches against an ArcGiS map 
 
 ## Important concepts
 
-When configuring the various options, it's important to remember that the widget is based on the [FindTask](https://developers.arcgis.com/javascript/jsapi/findtask-amd.html) and all results will be a FindResult object.  A FindResult object will contain a **feature** attribute which is a Graphic object.  This means it will have an **attributes** object with the properties of each result as specified by the layer in the base service.
+When configuring the various options, it's important to remember that the widget is based on the [FindTask](https://developers.arcgis.com/javascript/jsapi/findtask-amd.html) and all results will be a FindResult object.  A FindResult object will contain a `feature` attribute which is a Graphic object.  This means it will have an `attributes` object with the properties of each result as specified by the layer in the base service.
 
-It is important to recognize that the attribute names in this **attributes** property will be the field aliases specified for each field in the service definition and not the actual field name.
+It is important to recognize that the attribute names in this `attributes` property will be the field aliases specified for each field in the service definition and not the actual field name.
 
 It is also important to understand that different layers in a map service can have very different attributes but the grid columns you specify apply to all layers included in the search.  It is therefore recommended to achieve best results that you either limit the layers included in each search to layers that have similar attributes *or*, limit the columns you specify to fields shared by all layers in a search.
 
@@ -27,17 +27,9 @@ It is also important to understand that different layers in a map service can ha
 
 If you can control the service, it may be useful to use common aliases for fields in different layers.  For example:
 
-```
-PDNAME -> Name
-```
-
-```
-FDNAME -> Name
-```
-
-```
-RESNAME -> Name
-```
+- PDNAME -> Name
+- FDNAME -> Name
+- RESNAME -> Name
 
 You can also use a `get` function (detailed below) to compute and store a value on each FindResult item in your results.  A get function will be invoked and passed the FindResult object.  You can test for different properties to format the returned string.
 
@@ -49,21 +41,21 @@ Using an the array approach gives more flexibility but the object form is a hand
 
 ### As an array of objects
 
-Add a 'gridColumns' property to the search object.  The value should be an array of objects with the following properties:
+Add a `gridColumns` property to the search object.  The value should be an array of objects with the following properties:
 
-- 'field': this is the field alias of the column to get the value from.
-- 'get': this should be a function that accepts a find result item as the only argument and returns a string to display.
-- 'label': The column heading
-- 'resizable' <true/false>: whether or not the column can be resized
-- 'visible' <true/false>: set to false to compute and store a value on each FindResult item without displaying it in a column.  This is useful for sorting.
-- 'width': initial width of the column
+- `field`: this is the field alias of the column to get the value from.
+- `get`: this should be a function that accepts a find result item as the only argument and returns a string to display.
+- `label`: The column heading
+- `resizable` <true/false>: whether or not the column can be resized
+- `visible` <true/false>: set to false to compute and store a value on each FindResult item without displaying it in a column.  This is useful for sorting.
+- `width`: initial width of the column
 
 
 ### As an object
 
 This is a handy shortcut for specifying column defininitons but is much less flexible.  Check the dgrid documentation for details.
 
-Another way to specify a column is to use the get function.  Using this approach, the underlying dgrid instance will call the function you specify as the *get* property of a column object.  This function will receive the FindResult object and should return a string.  Check the Dgrid documentation for more information.
+Another way to specify a column is to use the get function.  Using this approach, the underlying dgrid instance will call the function you specify as the `get` property of a column object.  This function will receive the FindResult object and should return a string.  Check the Dgrid documentation for more information.
 
 You can specify a visible property for each property.  Setting this to false is a useful way of computing and storing a property which can be specified as a attribute to sort on but will not be shown in the grid:
 
@@ -87,17 +79,17 @@ sort: [
 
 ## Prompt
 
-You can add a **prompt** property to each query object to set the placeholder or prompt text in the search input for the query.
+You can add a `prompt` property to each query object to set the placeholder or prompt text in the search input for the query.
 
 ## Selection mode
 
-You can add a **selectionMode** property to control what results users can select in the results grid.  You need to specify any of the dgrid Selection mixin modes.
+You can add a `selectionMode` property to control what results users can select in the results grid.  You need to specify any of the dgrid Selection mixin modes.
 
-You can set this both for all queries (specify as a sibling of the **queries** property and optionally override for each query
+You can set this both for all queries (specify as a sibling of the `queries` property and optionally override for each query
 
 ## Symbology
 
-You can add a **resultsSymbols** property to override the default symbology of each FindResult.  You can also add a **selectedSymbols** property to override the symbology used to depict selected find results in the map.
+You can add a `resultsSymbols` property to override the default symbology of each FindResult.  You can also add a `selectedSymbols` property to override the symbology used to depict selected find results in the map.
 
 Each is an object with
 
@@ -109,7 +101,7 @@ properties.  Each of which must be a fully formed JSON symbol definition appropr
 
 ## Custom grid event functions
 
-You can add custom handlers for dgrid events by adding a **customGridHandlers** property which should be an array of objects:
+You can add custom handlers for dgrid events by adding a `customGridHandlers` property which should be an array of objects:
 
 ```
 customGridHandlers: [
@@ -120,8 +112,8 @@ customGridHandlers: [
 ]
 ```
 
-#### Example Config Object
-``` 
+## Example Config Object
+```
 find: {
     include: true,
     id: 'find',

--- a/widgets/Growler.md
+++ b/widgets/Growler.md
@@ -2,10 +2,10 @@
 
 A notification system using `dojo/topic`.
 
-##Topic Usage
+## Topic Usage
 By including the growler widget and using `topic.publish` you can create new growlers. This widget subscribes to the `'growler/growl'` topic.
 
-####Example usage:
+### Example:
 ```javascript
 geocoder.on('select', function(results){
     topic.publish('growler/growl', {
@@ -19,7 +19,7 @@ geocoder.on('select', function(results){
 });
 ```
 
-#### Example Config Object
+## Example Config Object
 ``` javascript
 growler: {
     include: true,

--- a/widgets/HomeButton.md
+++ b/widgets/HomeButton.md
@@ -2,7 +2,7 @@
 
 Esri's out-of-the-box home button widget. See `esri/dijit/HomeButton` [documentation](https://developers.arcgis.com/javascript/jsapi/homebutton-amd.html)
 
-#### Example Config Object
+## Example Config Object
 ``` javascript
 homeButton: {
     include: true,

--- a/widgets/Identify.md
+++ b/widgets/Identify.md
@@ -1,6 +1,6 @@
 # Identify
 
-#### Example Config Object
+## Example Config Object
 ``` javascript
 identify: {
    include: true,
@@ -11,12 +11,12 @@ identify: {
                   },
 ```
 
-### Identify widget configuration file
-The file can be found here `viewer/js/config/identify.js`. CMV comes with examples inside this file. Review this file on how to configure the widget for your use. 
+## Identify widget configuration file
+The file can be found here `viewer/js/config/identify.js`. CMV comes with examples inside this file. Review this file on how to configure the widget for your use.
 
 **Note** CMV uses the [PopupTemplate Class](https://developers.arcgis.com/javascript/jsapi/popuptemplate-amd.html) for the Identify widget. The  [ArcGIS JS API Documentation](https://developers.arcgis.com/javascript/jshelp/intro_popuptemplate.html) needs revision to clarify the use of the `fieldInfos:` array when using the PopupTemplate Class. On the page linked above the section named "fieldInfo structure:" states that `fieldName:` comes from the name of the field. This is vague and is clarified below.
 
-To display your identify results with attribute values you must **use the _field alias_ as defined in the map service rest end point** and _do not use any other field name or alias defined in the geodatabase_. 
+To display your identify results with attribute values you must **use the _field alias_ as defined in the map service rest end point** and _do not use any other field name or alias defined in the geodatabase_.
 
 You can not reliably use the field name or the alias as defined in the geodatabase. Nor can you reliably use the field name as defined in the map service. You must use the field alias as defined in the map service. Here are some situations as to why you can not reliably use the _field name_ as defined in the map service:
 
@@ -81,19 +81,14 @@ electric: {
 },
 ```
 
-![Identify Results](https://edop.gru.com/IdentifyResults.PNG)
-![FACILITYID](https://edop.gru.com/FacilityID.PNG)
-![Material](https://edop.gru.com/Material.PNG)
-![PoleSize](https://edop.gru.com/PoleSize.PNG)
-![Agreement](https://edop.gru.com/Agreement.PNG)
+## Build your own identify popup
 
-#### Using content formatter function in popup
-The JavascriptAPI has [a nice tutorial on formatting the info window content](https://developers.arcgis.com/javascript/jshelp/intro_formatinfowindow.html). Specifying a content formatter will allow you to do things like:
+The JavascriptAPI has [a nice tutorial](https://developers.arcgis.com/javascript/jshelp/intro_formatinfowindow.html) on formatting the info window content. Specifying a content formatter will allow you to do things like:
 * Programatically generate html for the popup (bullet list)
 * Alter field values (convert a image url to image)
 * Embed other widgets like a tab container and chart/table in the popup window
 
-At the time of this writing, the [develop branch of cmv](https://github.com/cmv/cmv-app/blob/develop/viewer/js/gis/dijit/Identify.js#L325) will check for a `content` property in each `identifies` object. This proerty can be either a **string or function**.
+The identify widget will check for a `content` property in each `identifies` object. This proerty can be either a **string or function**.
 Example usage:
 ``` javascript
 electric: {
@@ -164,7 +159,7 @@ var formatters = {
 };
 ```
 
-The final identify result: 
+The final identify result:
 ```JavaScript
 define([
     'dojo/_base/lang',

--- a/widgets/LocateButton.md
+++ b/widgets/LocateButton.md
@@ -1,7 +1,7 @@
 # Locate Button
 
-This widget is a wrapper around [LocateButton] (https://developers.arcgis.com/javascript/jsapi/locatebutton-amd.html).
-Centers map to user's location. You can suppress GPS data that will appear in a [InfoTemplate] (https://developers.arcgis.com/javascript/jsapi/infotemplate-amd.html)
+This widget is a wrapper around [LocateButton](https://developers.arcgis.com/javascript/jsapi/locatebutton-amd.html).
+Centers map to user's location. You can suppress GPS data that will appear in a [InfoTemplate](https://developers.arcgis.com/javascript/jsapi/infotemplate-amd.html)
 
 #### Example Config Object
 ``` javascript

--- a/widgets/Scalebar.md
+++ b/widgets/Scalebar.md
@@ -1,7 +1,7 @@
 # Scalebar
 
 ### scalebar
-See [Class : Scalebar] (https://developers.arcgis.com/javascript/jsapi/scalebar-amd.html) for parameters
+See [Class : Scalebar](https://developers.arcgis.com/javascript/jsapi/scalebar-amd.html) for parameters
 #### Example Config Object
 ``` javascript
 scalebar: {


### PR DESCRIPTION
- Added a little info to contributing to the documentation readme
- Fixed broken links in mkdocs (tested with current version of mkdocs)
- Removed broken image links in identify
- Adjusted lots of inconsistencies with headings and tabbage in code formatting blocks
- Updated identify config
- Add link to gitter.im in contributing guide
